### PR TITLE
mantela.json の 文法エラーを修正

### DIFF
--- a/mantela.json
+++ b/mantela.json
@@ -274,7 +274,7 @@
       "name": "Vanilla Ice Cream",
       "type": "unknown",
       "model": "Friend"
-    }
+    },
     {
       "extension": "5050",
       "identifier": "SHINANO15050",


### PR DESCRIPTION
277行目の末尾にカンマを追加します。
詳細は障害報告を参照してください